### PR TITLE
[WIP] Make more mobile-friendly

### DIFF
--- a/app/R/fxn_slsCardLayout.R
+++ b/app/R/fxn_slsCardLayout.R
@@ -57,7 +57,7 @@ fxn_slsCardLayout <- function(azmetStation, inDataLatest, slsCardGraphs) {
     
     class = "sls-card",
     fill = TRUE,
-    full_screen = FALSE,
+    full_screen = TRUE,
     height = cardHeight,
     id = NULL,
     max_height = cardHeight,
@@ -91,7 +91,7 @@ fxn_slsCardLayout <- function(azmetStation, inDataLatest, slsCardGraphs) {
     
     class = "sls-card",
     fill = TRUE,
-    full_screen = FALSE,
+    full_screen = TRUE,
     height = cardHeight,
     id = NULL,
     max_height = cardHeight,
@@ -125,7 +125,7 @@ fxn_slsCardLayout <- function(azmetStation, inDataLatest, slsCardGraphs) {
     
     class = "sls-card",
     fill = TRUE,
-    full_screen = FALSE,
+    full_screen = TRUE,
     height = cardHeight,
     id = NULL,
     max_height = cardHeight,
@@ -159,7 +159,7 @@ fxn_slsCardLayout <- function(azmetStation, inDataLatest, slsCardGraphs) {
     
     class = "sls-card",
     fill = TRUE,
-    full_screen = FALSE,
+    full_screen = TRUE,
     height = cardHeight,
     id = NULL,
     max_height = cardHeight,
@@ -199,7 +199,7 @@ fxn_slsCardLayout <- function(azmetStation, inDataLatest, slsCardGraphs) {
     
     class = "sls-card",
     fill = TRUE,
-    full_screen = FALSE,
+    full_screen = TRUE,
     height = cardHeight,
     id = NULL,
     max_height = cardHeight,
@@ -239,7 +239,7 @@ fxn_slsCardLayout <- function(azmetStation, inDataLatest, slsCardGraphs) {
     
     class = "sls-card",
     fill = TRUE,
-    full_screen = FALSE,
+    full_screen = TRUE,
     height = cardHeight,
     id = NULL,
     max_height = cardHeight,
@@ -278,7 +278,7 @@ fxn_slsCardLayout <- function(azmetStation, inDataLatest, slsCardGraphs) {
     
     class = "sls-card",
     fill = TRUE,
-    full_screen = FALSE,
+    full_screen = TRUE,
     height = cardHeight,
     id = NULL,
     max_height = cardHeight,
@@ -317,7 +317,7 @@ fxn_slsCardLayout <- function(azmetStation, inDataLatest, slsCardGraphs) {
     
     class = "sls-card",
     fill = TRUE,
-    full_screen = FALSE,
+    full_screen = TRUE,
     height = cardHeight,
     id = NULL,
     max_height = cardHeight,
@@ -356,7 +356,7 @@ fxn_slsCardLayout <- function(azmetStation, inDataLatest, slsCardGraphs) {
     
     class = "sls-card",
     fill = TRUE,
-    full_screen = FALSE,
+    full_screen = TRUE,
     height = cardHeight,
     id = NULL,
     max_height = cardHeight,
@@ -390,7 +390,7 @@ fxn_slsCardLayout <- function(azmetStation, inDataLatest, slsCardGraphs) {
     
     class = "sls-card",
     fill = TRUE,
-    full_screen = FALSE,
+    full_screen = TRUE,
     height = cardHeight,
     id = NULL,
     max_height = cardHeight,
@@ -429,7 +429,7 @@ fxn_slsCardLayout <- function(azmetStation, inDataLatest, slsCardGraphs) {
     
     class = "sls-card",
     fill = TRUE,
-    full_screen = FALSE,
+    full_screen = TRUE,
     height = cardHeight,
     id = NULL,
     max_height = cardHeight,
@@ -469,7 +469,7 @@ fxn_slsCardLayout <- function(azmetStation, inDataLatest, slsCardGraphs) {
     
     class = "sls-card",
     fill = TRUE,
-    full_screen = FALSE,
+    full_screen = TRUE,
     height = cardHeight,
     id = NULL,
     max_height = cardHeight,
@@ -509,7 +509,7 @@ fxn_slsCardLayout <- function(azmetStation, inDataLatest, slsCardGraphs) {
     
     class = "sls-card",
     fill = TRUE,
-    full_screen = FALSE,
+    full_screen = TRUE,
     height = cardHeight,
     id = NULL,
     max_height = cardHeight,
@@ -543,7 +543,7 @@ fxn_slsCardLayout <- function(azmetStation, inDataLatest, slsCardGraphs) {
     
     class = "sls-card",
     fill = TRUE,
-    full_screen = FALSE,
+    full_screen = TRUE,
     height = cardHeight,
     id = NULL,
     max_height = cardHeight,
@@ -583,7 +583,7 @@ fxn_slsCardLayout <- function(azmetStation, inDataLatest, slsCardGraphs) {
     
     class = "sls-card",
     fill = TRUE,
-    full_screen = FALSE,
+    full_screen = TRUE,
     height = cardHeight,
     id = NULL,
     max_height = cardHeight,
@@ -622,7 +622,7 @@ fxn_slsCardLayout <- function(azmetStation, inDataLatest, slsCardGraphs) {
     
     class = "sls-card",
     fill = TRUE,
-    full_screen = FALSE,
+    full_screen = TRUE,
     height = cardHeight,
     id = NULL,
     max_height = cardHeight,
@@ -662,7 +662,7 @@ fxn_slsCardLayout <- function(azmetStation, inDataLatest, slsCardGraphs) {
     
     class = "sls-card",
     fill = TRUE,
-    full_screen = FALSE,
+    full_screen = TRUE,
     height = cardHeight,
     id = NULL,
     max_height = cardHeight,
@@ -702,7 +702,7 @@ fxn_slsCardLayout <- function(azmetStation, inDataLatest, slsCardGraphs) {
     
     class = "sls-card",
     fill = TRUE,
-    full_screen = FALSE,
+    full_screen = TRUE,
     height = cardHeight,
     id = NULL,
     max_height = cardHeight,

--- a/app/app.R
+++ b/app/app.R
@@ -1,22 +1,21 @@
 # Tabular and graphical summaries of the most recent 15-minute data from stations across the network
 
-
 # UI --------------------
 
-ui <- 
+ui <-
   htmltools::htmlTemplate(
     filename = "azmet-shiny-template.html",
-    
+
     # Apparent bug in `bslib`, see: https://github.com/rstudio/bslib/issues/834
     #pageNavbar = bslib::page_navbar(
     #navsetTab = bslib::navset_tab(
     #navsetCardTab = bslib::navset_card_tab(
-    
+
     # Work-around by placing the navset in `bslib::page()`, which correctly renders tabs on webpage
     navsetCardTab = bslib::page(
       title = NULL,
       theme = theme, # `scr##_theme.R`
-      
+
       bslib::navset_card_tab(
         id = "navsetCardTab",
         selected = "network-wide-summary",
@@ -25,36 +24,42 @@ ui <-
         header = NULL,
         footer = NULL,
         #height = 600,
-        full_screen = TRUE,
+        full_screen = FALSE,
         #wrapper = card_body,
-        
+
         # Network-wide Summary (nws) -----
-        
+
         bslib::nav_panel(
-          title = "Network-wide Summary",
-          
+          title = div(
+            span("Network-wide Summary", class = "d-none d-lg-block"), #on devices "large" (lg) or larger
+            span("Network-wide", class = "d-block d-lg-none") #on smaller devices
+          ),
+
           shiny::htmlOutput(outputId = "nwsTableTitle"),
           shiny::htmlOutput(outputId = "nwsTableHelpText"),
           reactable::reactableOutput(outputId = "nwsTable"),
           shiny::htmlOutput(outputId = "nwsTableFooter"),
-          
+
           value = "network-wide-summary"
         ),
-        
+
         # Station-level summaries (sls) -----
-        
+
         bslib::nav_panel(
-          title = "Station-level Summaries",
-          
+          title = div(
+            span("Station-level Summaries", class = "d-none d-lg-block"),
+            span("Station-level", class = "d-block d-lg-none")
+          ),
+
           bslib::layout_sidebar(
             sidebar = slsSidebar, # `scr##_slsSidebar.R`
-            
+
             shiny::htmlOutput(outputId = "slsCardLayoutTitle"),
             shiny::htmlOutput(outputId = "slsCardLayoutHelpText"),
             shiny::htmlOutput(outputId = "slsLatestDataUpdate"),
             shiny::htmlOutput(outputId = "slsCardLayout"),
             shiny::htmlOutput(outputId = "slsCardLayoutFooter")
-            
+
             #fillable = TRUE,
             #fill = TRUE,
             #bg = NULL,
@@ -66,15 +71,15 @@ ui <-
             #gap = NULL,
             #height = 2000
           ),
-          
+
           value = "station-level-summaries"
         )
-       ) |>
+      ) |>
         htmltools::tagAppendAttributes(
           #https://getbootstrap.com/docs/5.0/utilities/api/
           class = "border-0 rounded-0 shadow-none"
         ),
-      
+
       shiny::htmlOutput(outputId = "refreshDataHelpText"), # Common, regardless of card tab
       shiny::uiOutput(outputId = "refreshDataButton"), # Common, regardless of card tab
       shiny::htmlOutput(outputId = "pageBottomText") # Common, regardless of card tab

--- a/app/app.R
+++ b/app/app.R
@@ -30,9 +30,10 @@ ui <-
         # Network-wide Summary (nws) -----
 
         bslib::nav_panel(
+          # https://getbootstrap.com/docs/5.0/utilities/display/#hiding-elements
           title = div(
-            span("Network-wide Summary", class = "d-none d-lg-block"), #on devices "large" (lg) or larger
-            span("Network-wide", class = "d-block d-lg-none") #on smaller devices
+            span("Network-wide Summary", class = "d-none d-md-block"), #on devices "medium" (md) or larger
+            span("Network-wide", class = "d-block d-md-none") #on smaller devices
           ),
 
           shiny::htmlOutput(outputId = "nwsTableTitle"),
@@ -47,8 +48,8 @@ ui <-
 
         bslib::nav_panel(
           title = div(
-            span("Station-level Summaries", class = "d-none d-lg-block"),
-            span("Station-level", class = "d-block d-lg-none")
+            span("Station-level Summaries", class = "d-none d-md-block"),
+            span("Station-level", class = "d-block d-md-none")
           ),
 
           bslib::layout_sidebar(


### PR DESCRIPTION
Basically I'm reading [this blog post](https://jnolis.com/blog/shiny_mobile/) and trying things out for now.  I've learned that bootstrap has [breakpoints](https://getbootstrap.com/docs/5.0/layout/breakpoints/) for different sizes of screens and you can use classes to give elements different behaviors as screen sizes change.  So far this helps out the mobile view by 1) making the tab names shorter on smaller screens so the tabs can stay side-by-side and 2) adding full-screen buttons to the plots (and removing them from the card containing the app body).