### PR TITLE
Convert to PWA

### DIFF
--- a/app/app.R
+++ b/app/app.R
@@ -15,7 +15,13 @@ ui <-
     navsetCardTab = bslib::page(
       title = NULL,
       theme = theme, # `scr##_theme.R`
-
+      shiny.pwa::pwa(
+        "https://viz.datascience.arizona.edu/azmet/azmet-in-real-time/",
+        title = "AZMet",
+        # TODO: replace with block A icon?  Can also be a path to a local file. E.g. "wws/icon.png"
+        icon = "https://github.com/uace-azmet/azmetr/blob/21f4b54f2b1d050fe75d191268274508d95071b6/pkgdown/favicon/apple-touch-icon.png",
+        output = "www"
+      ),
       bslib::navset_card_tab(
         id = "navsetCardTab",
         selected = "network-wide-summary",
@@ -32,7 +38,10 @@ ui <-
         bslib::nav_panel(
           # https://getbootstrap.com/docs/5.0/utilities/display/#hiding-elements
           title = htmltools::div(
-            htmltools::span("Network-wide Summary", class = "d-none d-md-block"), # on devices "medium" (md) or larger
+            htmltools::span(
+              "Network-wide Summary",
+              class = "d-none d-md-block"
+            ), # on devices "medium" (md) or larger
             htmltools::span("Network-wide...", class = "d-block d-md-none") # on smaller devices
           ),
 
@@ -47,7 +56,10 @@ ui <-
 
         bslib::nav_panel(
           title = htmltools::div(
-            htmltools::span("Station-level Summaries", class = "d-none d-md-block"),
+            htmltools::span(
+              "Station-level Summaries",
+              class = "d-none d-md-block"
+            ),
             htmltools::span("Station-level...", class = "d-block d-md-none")
           ),
 
@@ -82,10 +94,10 @@ ui <-
       htmltools::div(
         shiny::uiOutput(outputId = "refreshDataButton"),
         shiny::uiOutput(outputId = "refreshDataInfo"),
-        
+
         style = "display: flex; align-items: top; gap: 0px;", # Flexbox styling
       ),
-     
+
       shiny::htmlOutput(outputId = "pageBottomText") # Common, regardless of card tab
     )
   )

--- a/app/www/pwa-service-worker.js
+++ b/app/www/pwa-service-worker.js
@@ -1,0 +1,76 @@
+/*
+Copyright 2015, 2019 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+// Incrementing OFFLINE_VERSION will kick off the install event and force
+// previously cached resources to be updated from the network.
+const OFFLINE_VERSION = 1;
+const CACHE_NAME = 'offline';
+// Customize this with a different URL if needed.
+const OFFLINE_URL = 'pwa/offline.html';
+
+self.addEventListener('install', (event) => {
+  event.waitUntil((async () => {
+    const cache = await caches.open(CACHE_NAME);
+    // Setting {cache: 'reload'} in the new request will ensure that the response
+    // isn't fulfilled from the HTTP cache; i.e., it will be from the network.
+    await cache.add(new Request(OFFLINE_URL, {cache: 'reload'}));
+  })());
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil((async () => {
+    // Enable navigation preload if it's supported.
+    // See https://developers.google.com/web/updates/2017/02/navigation-preload
+    if ('navigationPreload' in self.registration) {
+      await self.registration.navigationPreload.enable();
+    }
+  })());
+
+  // Tell the active service worker to take control of the page immediately.
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  // We only want to call event.respondWith() if this is a navigation request
+  // for an HTML page.
+  if (event.request.mode === 'navigate') {
+    event.respondWith((async () => {
+      try {
+        // First, try to use the navigation preload response if it's supported.
+        const preloadResponse = await event.preloadResponse;
+        if (preloadResponse) {
+          return preloadResponse;
+        }
+
+        const networkResponse = await fetch(event.request);
+        return networkResponse;
+      } catch (error) {
+        // catch is only triggered if an exception is thrown, which is likely
+        // due to a network error.
+        // If fetch() returns a valid HTTP response with a response code in
+        // the 4xx or 5xx range, the catch() will NOT be called.
+        console.log('Fetch failed; returning offline page instead.', error);
+
+        const cache = await caches.open(CACHE_NAME);
+        const cachedResponse = await cache.match(OFFLINE_URL);
+        return cachedResponse;
+      }
+    })());
+  }
+
+  // If our if() condition is false, then this fetch handler won't intercept the
+  // request. If there are any other fetch handlers registered, they will get a
+  // chance to call event.respondWith(). If no fetch handlers call
+  // event.respondWith(), the request will be handled by the browser as if there
+  // were no service worker involvement.
+});


### PR DESCRIPTION
~~Adds a call to `shiny.pwa::pwa()` to allow this app to be installed as a progressive web app.~~
- [ ] Add files manually, without using `shiny.pwa`, as it may be abandoned (@Aariq)
- [ ] Create a square icon to be used as the app icon (@jeremylweiss)