### PR TITLE
Use browser cookie to remember selected station

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 # User-specific files
 .Ruserdata
+.vscode/settings.json
 
 # Example code in package build process
 *-Ex.R

--- a/app/R/_global.R
+++ b/app/R/_global.R
@@ -24,8 +24,8 @@ library(cookies)
 
 # Variables --------------------
 
-# Initialize, part of keeping `input$azmetStation` selection when refreshing data
-azmetStation <- shiny::reactiveVal(value = NULL)
+# # Initialize, part of keeping `input$azmetStation` selection when refreshing data
+# azmetStation <- shiny::reactiveVal(value = NULL)
 
 showPageBottomText <- shiny::reactiveVal(FALSE)
 

--- a/app/R/_global.R
+++ b/app/R/_global.R
@@ -11,10 +11,10 @@ library(RColorBrewer)
 library(reactable)
 library(shiny)
 library(shinyjs)
+library(cookies)
 
 
 # Files --------------------
-
 
 # Functions. Loaded automatically at app start if in `R` folder
 #source("./R/fxn_functionName.R", local = TRUE)
@@ -22,12 +22,10 @@ library(shinyjs)
 # Scripts. Loaded automatically at app start if in `R` folder
 #source("./R/scr_scriptName.R", local = TRUE)
 
-
 # Variables --------------------
 
-
 # Initialize, part of keeping `input$azmetStation` selection when refreshing data
-azmetStation <- shiny::reactiveVal(value = "Aguila")
+azmetStation <- shiny::reactiveVal(value = NULL)
 
 showPageBottomText <- shiny::reactiveVal(FALSE)
 

--- a/app/app.R
+++ b/app/app.R
@@ -132,7 +132,10 @@ server <-
       shiny::updateSelectInput(
         inputId = "azmetStation",
         label = "AZMet Station",
-        choices = sort(unique(az15min()$meta_station_name)),
+        choices = c(
+          "Select a station..." = "",
+          sort(unique(az15min()$meta_station_name))
+        ),
         selected = azmetStation() # Reactive value initialized in `_global.R`
       )
     })
@@ -163,6 +166,7 @@ server <-
     
     slsCardGraphs <- 
       shiny::eventReactive(c(input$azmetStation, az15min(), nwsData()), {
+        req(input$azmetStation)
         fxn_slsCardGraphs(
           azmetStation = input$azmetStation,
           inDataFull = az15min()
@@ -171,6 +175,7 @@ server <-
     
     slsCardLayout <- 
       shiny::eventReactive(c(input$azmetStation, nwsData(), slsCardGraphs()), {
+        req(input$azmetStation)
         fxn_slsCardLayout(
           azmetStation = input$azmetStation,
           inDataLatest = nwsData(),
@@ -249,20 +254,23 @@ server <-
         )
       })
     
-    output$slsCardLayoutFooter <- 
+    output$slsCardLayoutFooter <-
       shiny::renderUI({
+        req(input$azmetStation)
         shiny::req(az15min())
         fxn_slsCardLayoutFooter()
       })
     
     output$slsCardLayoutTitle <- 
       shiny::renderUI({
+        req(input$azmetStation)
         shiny::req(az15min())
         fxn_slsCardLayoutTitle(azmetStation = input$azmetStation)
       })
     
     output$slsLatestDataUpdate <- 
       shiny::renderUI({
+        req(input$azmetStation)
         shiny::req(az15min())
         fxn_slsLatestDataUpdate(
           azmetStation = input$azmetStation,

--- a/app/app.R
+++ b/app/app.R
@@ -1,6 +1,5 @@
 # Tabular and graphical summaries of the most recent 15-minute data from stations across the network
 
-
 # PROCESS FOR PWA -----
 
 # dir.create("app/www/pwa")
@@ -12,9 +11,7 @@
 # Copy `manifest.webmanifest` to `app/www/`
 # Add `tags$head(includeHTML("www/pwa/pwa.html"))` to `app.R`
 
-
 # UI --------------------
-
 
 ui <-
   htmltools::htmlTemplate(
@@ -26,86 +23,91 @@ ui <-
     #navsetCardTab = bslib::navset_card_tab(
 
     # Work-around by placing the navset in `bslib::page()`, which correctly renders tabs on webpage
-    navsetCardTab =
-      bslib::page(
+    navsetCardTab = bslib::page(
+      title = NULL,
+      theme = theme, # `scr##_theme.R`
+
+      htmltools::tags$head(htmltools::includeHTML("www/pwa.html")),
+
+      bslib::navset_card_tab(
+        id = "navsetCardTab",
+        selected = "network-wide-summary",
         title = NULL,
-        theme = theme, # `scr##_theme.R`
-        
-        htmltools::tags$head(htmltools::includeHTML("www/pwa.html")),
-        
-        bslib::navset_card_tab(
-          id = "navsetCardTab",
-          selected = "network-wide-summary",
-          title = NULL,
-          sidebar = NULL,
-          header = NULL,
-          footer = NULL,
-          height = 780,
-          full_screen = TRUE,
-          #wrapper = card_body,
-  
-          
-          # Network-wide Summary (nws) -----
-  
-          bslib::nav_panel(
-            # https://getbootstrap.com/docs/5.0/utilities/display/#hiding-elements
-            title = 
-              htmltools::div(
-                htmltools::span("Network-wide Summary", class = "d-none d-md-block"), # on devices "medium" (md) or larger
-                htmltools::span("Network-wide...", class = "d-block d-md-none") # on smaller devices
-              ),
-  
-            shiny::htmlOutput(outputId = "nwsTableTitle"),
-            reactable::reactableOutput(outputId = "nwsTable", height = "100%"),
-            shiny::htmlOutput(outputId = "nwsTableFooter"),
-  
-            value = "network-wide-summary"
+        sidebar = NULL,
+        header = NULL,
+        footer = NULL,
+        height = 780,
+        full_screen = TRUE,
+        #wrapper = card_body,
+
+        # Network-wide Summary (nws) -----
+
+        bslib::nav_panel(
+          # https://getbootstrap.com/docs/5.0/utilities/display/#hiding-elements
+          title = htmltools::div(
+            htmltools::span(
+              "Network-wide Summary",
+              class = "d-none d-md-block"
+            ), # on devices "medium" (md) or larger
+            htmltools::span("Network-wide...", class = "d-block d-md-none") # on smaller devices
           ),
-  
-          
-          # Station-level Summaries (sls) -----
-  
-          bslib::nav_panel(
-            title = htmltools::div(
-              htmltools::span("Station-level Summaries", class = "d-none d-md-block"),
-              htmltools::span("Station-level...", class = "d-block d-md-none")
-            ),
-  
-            bslib::layout_sidebar(
-              sidebar = slsSidebar, # `scr##_slsSidebar.R`
-  
-              shiny::htmlOutput(outputId = "slsCardLayoutTitle"),
-              shiny::htmlOutput(outputId = "slsLatestDataUpdate"),
-              shiny::htmlOutput(outputId = "slsCardLayout"),
-              shiny::htmlOutput(outputId = "slsCardLayoutFooter")
-  
-              #fillable = TRUE,
-              #fill = TRUE,
-              #bg = NULL,
-              #fg = NULL,
-              #border = NULL,
-              #border_radius = NULL,
-              #border_color = NULL,
-              #padding = NULL,
-              #gap = NULL,
-              #height = 2000
-            ),
-  
-            value = "station-level-summaries"
-          )
-        ) |>
-          htmltools::tagAppendAttributes(class = "border-0 rounded-0 shadow-none"), # https://getbootstrap.com/docs/5.0/utilities/api/
-  
-        htmltools::div(
-          shiny::uiOutput(outputId = "refreshDataButton"),
-          shiny::uiOutput(outputId = "refreshDataInfo"),
-  
-          style = "display: flex; align-items: top; gap: 0px;", # Flexbox styling
+
+          shiny::htmlOutput(outputId = "nwsTableTitle"),
+          reactable::reactableOutput(outputId = "nwsTable", height = "100%"),
+          shiny::htmlOutput(outputId = "nwsTableFooter"),
+
+          value = "network-wide-summary"
         ),
-  
-        shiny::htmlOutput(outputId = "pageBottomText") # Common, regardless of card tab
-      )
-  )
+
+        # Station-level Summaries (sls) -----
+
+        bslib::nav_panel(
+          title = htmltools::div(
+            htmltools::span(
+              "Station-level Summaries",
+              class = "d-none d-md-block"
+            ),
+            htmltools::span("Station-level...", class = "d-block d-md-none")
+          ),
+
+          bslib::layout_sidebar(
+            sidebar = slsSidebar, # `scr##_slsSidebar.R`
+
+            shiny::htmlOutput(outputId = "slsCardLayoutTitle"),
+            shiny::htmlOutput(outputId = "slsLatestDataUpdate"),
+            shiny::htmlOutput(outputId = "slsCardLayout"),
+            shiny::htmlOutput(outputId = "slsCardLayoutFooter")
+
+            #fillable = TRUE,
+            #fill = TRUE,
+            #bg = NULL,
+            #fg = NULL,
+            #border = NULL,
+            #border_radius = NULL,
+            #border_color = NULL,
+            #padding = NULL,
+            #gap = NULL,
+            #height = 2000
+          ),
+
+          value = "station-level-summaries"
+        )
+      ) |>
+        htmltools::tagAppendAttributes(
+          class = "border-0 rounded-0 shadow-none"
+        ), # https://getbootstrap.com/docs/5.0/utilities/api/
+
+      htmltools::div(
+        shiny::uiOutput(outputId = "refreshDataButton"),
+        shiny::uiOutput(outputId = "refreshDataInfo"),
+
+        style = "display: flex; align-items: top; gap: 0px;", # Flexbox styling
+      ),
+
+      shiny::htmlOutput(outputId = "pageBottomText") # Common, regardless of card tab
+    )
+  ) |>
+  cookies::add_cookie_handlers()
 
 
 # Server --------------------
@@ -139,15 +141,27 @@ server <-
         selected = azmetStation() # Reactive value initialized in `_global.R`
       )
     })
-    
-    shiny::observeEvent(input$azmetStation, {
-      azmetStation(input$azmetStation)
-    }, 
+
+    shiny::observeEvent(
+      input$azmetStation,
+      {
+        azmetStation(input$azmetStation)
+        cookies::set_cookie(
+          cookie_name = "azmetStation",
+          cookie_value = azmetStation()
+        )
+      },
       ignoreInit = TRUE
     )
   
     
     # Reactives -----
+
+    # Initialize, part of keeping `input$azmetStation` selection when refreshing
+    # data
+    azmetStation <- shiny::reactiveVal(
+      value = isolate(cookies::get_cookie("azmetStation"))
+    )
     
     az15min <- 
       shiny::reactive({

--- a/renv.lock
+++ b/renv.lock
@@ -41,17 +41,6 @@
       ],
       "Hash": "f6a81550f166acbe2cd5229e9ca079b9"
     },
-    "PKI": {
-      "Package": "PKI",
-      "Version": "0.1-14",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "base64enc"
-      ],
-      "Hash": "f5b9c6b2f62f1fa3dd53fd1ddccbb241"
-    },
     "R6": {
       "Package": "R6",
       "Version": "2.6.1",
@@ -82,17 +71,6 @@
         "utils"
       ],
       "Hash": "e7bdd9ee90e96921ca8a0f1972d66682"
-    },
-    "RcppTOML": {
-      "Package": "RcppTOML",
-      "Version": "0.2.3",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "Rcpp"
-      ],
-      "Hash": "23eeca7d3c7d63fc7449108c0a66178c"
     },
     "askpass": {
       "Package": "askpass",
@@ -207,12 +185,48 @@
       ],
       "Hash": "16850760556401a2eeb27d39bd11c9cb"
     },
+    "clock": {
+      "Package": "clock",
+      "Version": "0.7.4",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "cli",
+        "cpp11",
+        "lifecycle",
+        "rlang",
+        "tzdb",
+        "vctrs"
+      ],
+      "Hash": "dce6a8b20db8fc2fe9967d85f770b475"
+    },
     "commonmark": {
       "Package": "commonmark",
       "Version": "2.0.0",
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "8cba62334c1088d21689d353a7e87663"
+    },
+    "cookies": {
+      "Package": "cookies",
+      "Version": "0.2.3",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "cli",
+        "clock",
+        "glue",
+        "htmltools",
+        "httpuv",
+        "jsonlite",
+        "purrr",
+        "rlang",
+        "shiny",
+        "stats",
+        "vctrs"
+      ],
+      "Hash": "ec07bfdaeb45d6ab53b51d99c3dd3131"
     },
     "cpp11": {
       "Package": "cpp11",
@@ -697,18 +711,6 @@
       ],
       "Hash": "627d6993db1043703c0b084fa432f21f"
     },
-    "packrat": {
-      "Package": "packrat",
-      "Version": "0.9.3",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "tools",
-        "utils"
-      ],
-      "Hash": "d3289899c84c65def1a783ea0a9ea0eb"
-    },
     "pillar": {
       "Package": "pillar",
       "Version": "1.10.2",
@@ -878,38 +880,6 @@
       ],
       "Hash": "df99277f63d01c34e95e3d2f06a79736"
     },
-    "rsconnect": {
-      "Package": "rsconnect",
-      "Version": "1.5.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "PKI",
-        "R",
-        "cli",
-        "curl",
-        "digest",
-        "jsonlite",
-        "lifecycle",
-        "openssl",
-        "packrat",
-        "renv",
-        "rlang",
-        "rstudioapi",
-        "snowflakeauth",
-        "tools",
-        "utils",
-        "yaml"
-      ],
-      "Hash": "43ac7d36cea2d468918e604c9e823e80"
-    },
-    "rstudioapi": {
-      "Package": "rstudioapi",
-      "Version": "0.17.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "5f90cd73946d706cfe26024294236113"
-    },
     "sass": {
       "Package": "sass",
       "Version": "0.4.10",
@@ -989,20 +959,6 @@
         "shiny"
       ],
       "Hash": "802e4786b353a4bb27116957558548d5"
-    },
-    "snowflakeauth": {
-      "Package": "snowflakeauth",
-      "Version": "0.1.2",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "RcppTOML",
-        "cli",
-        "curl",
-        "jsonlite",
-        "rlang"
-      ],
-      "Hash": "e32f00aeec04ec7d1151dde27ea065b8"
     },
     "sourcetools": {
       "Package": "sourcetools",
@@ -1129,6 +1085,17 @@
         "xfun"
       ],
       "Hash": "02d65e0c0415bf36a7ddc0d2ba50a840"
+    },
+    "tzdb": {
+      "Package": "tzdb",
+      "Version": "0.5.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "cpp11"
+      ],
+      "Hash": "09e3961e87b7bafa4a9340bbb34aeda8"
     },
     "utf8": {
       "Package": "utf8",


### PR DESCRIPTION
This supersedes the `cookies` branch.  Closes #19.  Unfortunately, it causes the app to crash when viewed in the Positron viewer pane because cookies can't be set there (see https://github.com/shinyworks/cookies/issues/91)